### PR TITLE
Bugfix: check that ga is available

### DIFF
--- a/assets/js/gaEvents.js
+++ b/assets/js/gaEvents.js
@@ -1,28 +1,31 @@
-// GA hooks for tracking voting registration conversions
-$('#form-voting').on('click', function() {
-	ga('send', 'event', 'vote', 'register', 'form');
-	// Optimizely event support
-	window['optimizely'] = window['optimizely'] || [];
-	window.optimizely.push(["trackEvent", "voterSignup"]);
-});
-$('#online-voting').on('click', function() {
-	ga('send', 'event', 'vote', 'register', 'online');
-	// Optimizely event support
-	window['optimizely'] = window['optimizely'] || [];
-	window.optimizely.push(["trackEvent", "voterSignup"]);
-});
-$('#inperson-voting').on('click', function() {
-	ga('send', 'event', 'vote', 'register', 'inperson');
-	// Optimizely event support
-	window['optimizely'] = window['optimizely'] || [];
-	window.optimizely.push(["trackEvent", "voterSignup"]);
-});
+// GA hooks for tracking voting registration conversions.
+// Check that ga object is available, then add hooks.
+if (ga) {
+  $('#form-voting').on('click', function() {
+    ga('send', 'event', 'vote', 'register', 'form');
+    // Optimizely event support
+    window['optimizely'] = window['optimizely'] || [];
+    window.optimizely.push(["trackEvent", "voterSignup"]);
+  });
+  $('#online-voting').on('click', function() {
+    ga('send', 'event', 'vote', 'register', 'online');
+    // Optimizely event support
+    window['optimizely'] = window['optimizely'] || [];
+    window.optimizely.push(["trackEvent", "voterSignup"]);
+  });
+  $('#inperson-voting').on('click', function() {
+    ga('send', 'event', 'vote', 'register', 'inperson');
+    // Optimizely event support
+    window['optimizely'] = window['optimizely'] || [];
+    window.optimizely.push(["trackEvent", "voterSignup"]);
+  });
 
-// GA hook for tracking whether the user selected a state
-$('select').on('change', function() {
-  var state = this.value;
-  ga('send', 'event', 'vote', 'select', state);
-	// Optimizely event support
-	window['optimizely'] = window['optimizely'] || [];
-	window.optimizely.push(["trackEvent", "stateSelect"]);
-});
+  // GA hook for tracking whether the user selected a state.
+  $('select').on('change', function() {
+    var state = this.value;
+    ga('send', 'event', 'vote', 'select', state);
+    // Optimizely event support
+    window['optimizely'] = window['optimizely'] || [];
+    window.optimizely.push(["trackEvent", "stateSelect"]);
+  });
+}


### PR DESCRIPTION
[Live site](https://vote.usa.gov/) has a bug where ga is not defined:

![screen shot 2016-02-28 at 3 14 21 pm](https://cloud.githubusercontent.com/assets/704760/13381639/b7c0a142-de2e-11e5-87be-11ab4d71d25d.png)

This wraps the event handlers that call `ga` in an `if` statement that checks whether `ga` is defined before the handlers are set.

Also, can issues be opened on this repo for members of https://github.com/government? It seems odd that I can't open an issue.
