### PR TITLE
Update KS voter registration website link

### DIFF
--- a/assets/js/stateSelect.js
+++ b/assets/js/stateSelect.js
@@ -30,7 +30,7 @@ var stateWebsites = [
   { "state": "IA", "website": "https://sos.iowa.gov/elections/voterinformation/voterregistration.html" },
   { "state": "IL", "website": "https://ova.elections.il.gov/" },
   { "state": "IN", "website": "http://indianavoters.in.gov/PublicSite/OVR/Introduction.aspx" },
-  { "state": "KS", "website": "https://www.kdor.org/voterregistration/Default.aspx" },
+  { "state": "KS", "website": "https://www.kdor.ks.gov/Apps/VoterReg/Default.aspx" },
   { "state": "KY", "website": "https://vrsws.sos.ky.gov/ovrweb/"},
   { "state": "LA", "website": "http://www.sos.la.gov/ElectionsAndVoting/Pages/OnlineVoterRegistration.aspx" },
   { "state": "MA", "website": "https://www.sec.state.ma.us/ovr/" },


### PR DESCRIPTION
Howdy! 

Right now when a voter from Kansas looks for voter registration information, they are pointed to an older webpage:

![ks1](https://cloud.githubusercontent.com/assets/3209501/17221278/dbf93a6e-54b8-11e6-928c-125d6622e4df.png)

![ks2](https://cloud.githubusercontent.com/assets/3209501/17221251/b71078e8-54b8-11e6-8b52-350e1279e8e0.png)

This PR saves potential Kansas voters a click.  😊 
